### PR TITLE
GitHub workflows to update cm_model_catalog.md in views_pipeline

### DIFF
--- a/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
+++ b/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
@@ -38,6 +38,11 @@ jobs:
         cd views_pipeline
         python documentation/catalogs/generate_links_to_querysets.py
 
+    - name: Configure Git
+      run: |
+        git config --global user.name "GitHub Actions"
+        git config --global user.email "actions@github.com"
+
     - name: Commit and Push Changes
       run: |
         cd views_pipeline

--- a/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
+++ b/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
@@ -20,7 +20,6 @@ jobs:
       run: echo "Starting workflow to update views_pipeline..."
 
     - name: Checkout viewsforecasting repository
-      run: echo "Checking out viewsforecasting repository..."
       uses: actions/checkout@v3
       with:
         repository: prio-data/viewsforecasting

--- a/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
+++ b/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
@@ -16,36 +16,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Echo Step 1 - Starting Workflow
-      run: echo "Starting workflow to update views_pipeline..."
-
     - name: Checkout viewsforecasting repository
       uses: actions/checkout@v3
       with:
         repository: prio-data/viewsforecasting
         token: ${{ secrets.VIEWS_PIPELINE_ACCESS_TOKEN }}
 
-    - name: Echo Step 2 - Cloning views_pipeline repository
-      run: echo "Cloning views_pipeline repository..."
-
     - name: Clone views_pipeline repository
       run: |
         git clone https://github.com/prio-data/views_pipeline.git
         cd views_pipeline
         git checkout create_cm_catalog_01
-      continue-on-error: false
 
-    - name: Echo Step 3 - Running generate_links_to_querysets.py
-      run: echo "Running generate_links_to_querysets.py..."
+    - name: Clone viewsforecasting repository 
+      run: |
+        cd views_pipeline
+        git clone https://github.com/prio-data/viewsforecasting.git ../viewsforecasting
 
     - name: Run Python script  
       run: |
         cd views_pipeline
         python documentation/catalogs/generate_links_to_querysets.py
-      continue-on-error: false
-
-    - name: Echo Step 4 - Committing changes
-      run: echo "Committing and pushing changes..."
 
     - name: Commit and Push Changes
       run: |
@@ -55,8 +46,5 @@ jobs:
         git push origin create_cm_catalog_01
       env:
         GITHUB_TOKEN: ${{ secrets.VIEWS_PIPELINE_ACCESS_TOKEN }}
-
-    - name: Echo Step 5 - Workflow completed
-      run: echo "Workflow completed successfully!"
 
 

--- a/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
+++ b/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
@@ -4,8 +4,8 @@ name: dispatch event to views_pipeline on changes in cm_querysets.py and pgm_que
 on:
   push:
     branches:
-      - github_workflows
       - main
+      - github_workflows
     paths:
       - Tools/cm_querysets.py
       - Tools/pgm_querysets.py

--- a/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
+++ b/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - github_workflows 
+      - github_workflows # TODO: remove when merge to main
     paths:
       - Tools/cm_querysets.py
       - Tools/pgm_querysets.py
@@ -33,11 +33,11 @@ jobs:
         cd views_pipeline
         git clone https://github.com/prio-data/viewsforecasting.git ../viewsforecasting
 
-    # this step should be removed when merged to main
+    # TODO: this step should be removed when merged to main
     - name: Checkout github_workflows branch in viewsforecasting
       run: |
         cd ../viewsforecasting
-        git checkout GitHub_workflows
+        git checkout github_workflows
 
     - name: Run Python script  
       run: |

--- a/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
+++ b/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
@@ -1,4 +1,4 @@
-name: dispatch event to views_pipeline on changes in cm_querysets.py and pgm_querysets.py
+name: Update views_pipeline on Changes in cm_querysets.py and pgm_querysets.py
 
 # Trigger on file changes in viewsforecasting
 on:
@@ -18,12 +18,12 @@ jobs:
     - name: Checkout viewsforecasting repository
       uses: actions/checkout@v3
       with:
-        repository: lujzi05/viewsforecasting
+        repository: prio-data/viewsforecasting
         token: ${{ secrets.VIEWS_PIPELINE_ACCESS_TOKEN }}
 
     - name: Clone views_pipeline repository
       run: |
-        git clone https://github.com/your_username/lujzi05/views_pipeline.git
+        git clone https://github.com/prio-data/views_pipeline.git
         cd views_pipeline
         git checkout create_cm_catalog_01
 

--- a/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
+++ b/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
@@ -30,17 +30,11 @@ jobs:
 
     - name: Clone viewsforecasting repository 
       run: |
-        cd views_pipeline
-        git clone https://github.com/prio-data/viewsforecasting.git ../viewsforecasting
+        git clone https://github.com/prio-data/viewsforecasting.git 
+        cd viewsforecasting
         git status
-
-    # TODO: this step should be removed when merged to main
-    - name: Checkout github_workflows branch in viewsforecasting
-      run: |
-        cd ../viewsforecasting
-        git status
-        git checkout github_workflows
-        git status
+        git checkout github_workflows 
+      # TODO: git checkout github_workflows should be removed when merged to main
 
     - name: Run Python script  
       run: |
@@ -58,7 +52,7 @@ jobs:
         cd views_pipeline
         git status
         git add documentation/catalogs/cm_model_catalog.md
-        git commit -m "Automated changes by GitHub Actions"
+        git commit -m "Automated changes by GitHub Actions" || echo "Nothing to commit"
         git push https://${{ secrets.VIEWS_PIPELINE_ACCESS_TOKEN }}:x-oauth-basic@github.com/prio-data/views_pipeline.git create_cm_catalog_01
       
 

--- a/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
+++ b/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - github_workflows
+      - main
     paths:
       - Tools/cm_querysets.py
       - Tools/pgm_querysets.py

--- a/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
+++ b/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
@@ -9,28 +9,44 @@ on:
     paths:
       - Tools/cm_querysets.py
       - Tools/pgm_querysets.py
+  workflow_dispatch:
 
 jobs:
   modify-views_pipeline:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Echo Step 1 - Starting Workflow
+      run: echo "Starting workflow to update views_pipeline..."
+
     - name: Checkout viewsforecasting repository
+      run: echo "Checking out viewsforecasting repository..."
       uses: actions/checkout@v3
       with:
         repository: prio-data/viewsforecasting
         token: ${{ secrets.VIEWS_PIPELINE_ACCESS_TOKEN }}
+
+    - name: Echo Step 2 - Cloning views_pipeline repository
+      run: echo "Cloning views_pipeline repository..."
 
     - name: Clone views_pipeline repository
       run: |
         git clone https://github.com/prio-data/views_pipeline.git
         cd views_pipeline
         git checkout create_cm_catalog_01
+      continue-on-error: false
+
+    - name: Echo Step 3 - Running generate_links_to_querysets.py
+      run: echo "Running generate_links_to_querysets.py..."
 
     - name: Run Python script  
       run: |
         cd views_pipeline
         python documentation/catalogs/generate_links_to_querysets.py
+      continue-on-error: false
+
+    - name: Echo Step 4 - Committing changes
+      run: echo "Committing and pushing changes..."
 
     - name: Commit and Push Changes
       run: |
@@ -40,5 +56,8 @@ jobs:
         git push origin create_cm_catalog_01
       env:
         GITHUB_TOKEN: ${{ secrets.VIEWS_PIPELINE_ACCESS_TOKEN }}
+
+    - name: Echo Step 5 - Workflow completed
+      run: echo "Workflow completed successfully!"
 
 

--- a/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
+++ b/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
@@ -5,18 +5,18 @@ on:
   push:
     branches:
       - main
-      - github_workflows
+      - github_workflows 
     paths:
       - Tools/cm_querysets.py
       - Tools/pgm_querysets.py
-  workflow_dispatch:
+  workflow_dispatch: # enables manual triggering
 
 jobs:
   modify-views_pipeline:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout viewsforecasting repository
+    - name: Checkout viewsforecasting repository 
       uses: actions/checkout@v3
       with:
         repository: prio-data/viewsforecasting
@@ -32,6 +32,12 @@ jobs:
       run: |
         cd views_pipeline
         git clone https://github.com/prio-data/viewsforecasting.git ../viewsforecasting
+
+    # this step should be removed when merged to main
+    - name: Checkout github_workflows branch in viewsforecasting
+      run: |
+        cd ../viewsforecasting
+        git checkout GitHub_workflows
 
     - name: Run Python script  
       run: |

--- a/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
+++ b/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
@@ -48,8 +48,7 @@ jobs:
         cd views_pipeline
         git add documentation/catalogs/cm_model_catalog.md
         git commit -m "Automated changes by GitHub Actions"
-        git push origin create_cm_catalog_01
-      env:
-        GITHUB_TOKEN: ${{ secrets.VIEWS_PIPELINE_ACCESS_TOKEN }}
+        git push https://${{ secrets.VIEWS_PIPELINE_ACCESS_TOKEN }}:x-oauth-basic@github.com/prio-data/views_pipeline.git create_cm_catalog_01
+      
 
 

--- a/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
+++ b/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout views_pipeline repository
+    - name: Checkout viewsforecasting repository
       uses: actions/checkout@v3
       with:
-        repository: lujzi05/views_pipeline
+        repository: lujzi05/viewsforecasting
         token: ${{ secrets.VIEWS_PIPELINE_ACCESS_TOKEN }}
 
-    - name: Clone viewsforecasting repository
+    - name: Clone views_pipeline repository
       run: |
         git clone https://github.com/your_username/lujzi05/views_pipeline.git
         cd views_pipeline
@@ -29,10 +29,12 @@ jobs:
 
     - name: Run Python script  
       run: |
+        cd views_pipeline
         python documentation/catalogs/generate_links_to_querysets.py
 
     - name: Commit and Push Changes
       run: |
+        cd views_pipeline
         git add documentation/catalogs/cm_model_catalog.md
         git commit -m "Automated changes by GitHub Actions"
         git push origin create_cm_catalog_01

--- a/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
+++ b/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
@@ -37,6 +37,6 @@ jobs:
         git commit -m "Automated changes by GitHub Actions"
         git push origin create_cm_catalog_01
       env:
-        GITHUB_TOKEN: ${{ secrets.GVIEWS_PIPELINE_ACCESS_TOKENN }}
+        GITHUB_TOKEN: ${{ secrets.VIEWS_PIPELINE_ACCESS_TOKEN }}
 
 

--- a/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
+++ b/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
@@ -11,14 +11,32 @@ on:
       - Tools/pgm_querysets.py
 
 jobs:
-  dispatch:
+  modify-views_pipeline:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Trigger repository dispatch in views_pipeline
+    - name: Checkout views_pipeline repository
+      uses: actions/checkout@v3
+      with:
+        repository: lujzi05/views_pipeline
+        token: ${{ secrets.VIEWS_PIPELINE_ACCESS_TOKEN }}
+
+    - name: Clone viewsforecasting repository
       run: |
-        curl -X POST \
-          -H "Authorization: token ${{ secrets.VIEWS_PIPELINE_ACCESS_TOKEN }}" \
-          -H "Accept: application/vnd.github.v3+json" \
-          https://api.github.com/repos/lujzi05/views_pipeline/dispatches \
-          -d '{"event_type": "trigger-generate_links_to_querysets"}'
+        git clone https://github.com/your_username/lujzi05/views_pipeline.git
+        cd views_pipeline
+        git checkout create_cm_catalog_01
+
+    - name: Run Python script  
+      run: |
+        python documentation/catalogs/generate_links_to_querysets.py
+
+    - name: Commit and Push Changes
+      run: |
+        git add documentation/catalogs/cm_model_catalog.md
+        git commit -m "Automated changes by GitHub Actions"
+        git push origin create_cm_catalog_01
+      env:
+        GITHUB_TOKEN: ${{ secrets.GVIEWS_PIPELINE_ACCESS_TOKENN }}
+
+

--- a/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
+++ b/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
@@ -32,16 +32,20 @@ jobs:
       run: |
         cd views_pipeline
         git clone https://github.com/prio-data/viewsforecasting.git ../viewsforecasting
+        git status
 
     # TODO: this step should be removed when merged to main
     - name: Checkout github_workflows branch in viewsforecasting
       run: |
         cd ../viewsforecasting
+        git status
         git checkout github_workflows
+        git status
 
     - name: Run Python script  
       run: |
         cd views_pipeline
+        git status
         python documentation/catalogs/generate_links_to_querysets.py
 
     - name: Configure Git
@@ -52,6 +56,7 @@ jobs:
     - name: Commit and Push Changes
       run: |
         cd views_pipeline
+        git status
         git add documentation/catalogs/cm_model_catalog.md
         git commit -m "Automated changes by GitHub Actions"
         git push https://${{ secrets.VIEWS_PIPELINE_ACCESS_TOKEN }}:x-oauth-basic@github.com/prio-data/views_pipeline.git create_cm_catalog_01

--- a/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
+++ b/.github/workflows/trigger_views_pipeline_cm_catalog_dispatch.yml
@@ -1,0 +1,23 @@
+name: dispatch event to views_pipeline on changes in cm_querysets.py and pgm_querysets.py
+
+# Trigger on file changes in viewsforecasting
+on:
+  push:
+    branches:
+      - github_workflows
+    paths:
+      - Tools/cm_querysets.py
+      - Tools/pgm_querysets.py
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Trigger repository dispatch in views_pipeline
+      run: |
+        curl -X POST \
+          -H "Authorization: token ${{ secrets.VIEWS_PIPELINE_ACCESS_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/lujzi05/views_pipeline/dispatches \
+          -d '{"event_type": "trigger-generate_links_to_querysets"}'

--- a/.github/workflows/update_views_pipeline_cm_catalog.yml
+++ b/.github/workflows/update_views_pipeline_cm_catalog.yml
@@ -32,7 +32,6 @@ jobs:
       run: |
         git clone https://github.com/prio-data/viewsforecasting.git 
         cd viewsforecasting
-        git status
         git checkout github_workflows 
       # TODO: git checkout github_workflows should be removed when merged to main
 
@@ -50,7 +49,6 @@ jobs:
     - name: Commit and Push Changes
       run: |
         cd views_pipeline
-        git status
         git add documentation/catalogs/cm_model_catalog.md
         git commit -m "Automated changes by GitHub Actions" || echo "Nothing to commit"
         git push https://${{ secrets.VIEWS_PIPELINE_ACCESS_TOKEN }}:x-oauth-basic@github.com/prio-data/views_pipeline.git create_cm_catalog_01

--- a/Tools/cm_querysets.py
+++ b/Tools/cm_querysets.py
@@ -21,13 +21,6 @@ THIS IS SOME BLANK SPACE TO TEST THE GITHUB WORKFLOW
 
 
 
-
-
-
-
-
-
-
 '''
 
 def get_cm_querysets():

--- a/Tools/cm_querysets.py
+++ b/Tools/cm_querysets.py
@@ -14,6 +14,20 @@ from viewser import Queryset, Column
 
 THIS IS SOME BLANK SPACE TO TEST THE GITHUB WORKFLOW
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 '''
 
 def get_cm_querysets():

--- a/Tools/cm_querysets.py
+++ b/Tools/cm_querysets.py
@@ -9,6 +9,14 @@
 import numpy as np
 from viewser import Queryset, Column
 
+'''
+
+
+THIS IS SOME BLANK SPACE TO TEST THE GITHUB WORKFLOW
+
+
+'''
+
 def get_cm_querysets():
 
 

--- a/Tools/cm_querysets.py
+++ b/Tools/cm_querysets.py
@@ -15,6 +15,11 @@ from viewser import Queryset, Column
 THIS IS SOME BLANK SPACE TO TEST THE GITHUB WORKFLOW
 
 
+
+
+
+
+
 '''
 
 def get_cm_querysets():

--- a/Tools/cm_querysets.py
+++ b/Tools/cm_querysets.py
@@ -15,12 +15,6 @@ from viewser import Queryset, Column
 THIS IS SOME BLANK SPACE TO TEST THE GITHUB WORKFLOW
 
 
-
-
-
-
-
-
 '''
 
 def get_cm_querysets():

--- a/Tools/cm_querysets.py
+++ b/Tools/cm_querysets.py
@@ -14,12 +14,6 @@ from viewser import Queryset, Column
 
 THIS IS SOME BLANK SPACE TO TEST THE GITHUB WORKFLOW
 
-
-
-
-
-
-
 '''
 
 def get_cm_querysets():

--- a/Tools/pgm_querysets.py
+++ b/Tools/pgm_querysets.py
@@ -10,6 +10,8 @@ import numpy as np
 from viewser import Queryset, Column
 
 '''
+
+
 THIS IS SOME BLANK SPACE TO TEST THE GITHUB WORKFLOW
 
 

--- a/Tools/pgm_querysets.py
+++ b/Tools/pgm_querysets.py
@@ -10,8 +10,6 @@ import numpy as np
 from viewser import Queryset, Column
 
 '''
-
-
 THIS IS SOME BLANK SPACE TO TEST THE GITHUB WORKFLOW
 
 

--- a/Tools/pgm_querysets.py
+++ b/Tools/pgm_querysets.py
@@ -9,7 +9,13 @@
 import numpy as np
 from viewser import Queryset, Column
 
+'''
 
+
+THIS IS SOME BLANK SPACE TO TEST THE GITHUB WORKFLOW
+
+
+'''
 def report(df):
     print()
     print(f"A dataset with {len(df.columns)} columns, with "


### PR DESCRIPTION
It is a GitHub workflow that update cm_model_catalog.md in views_pipeline. It can be tested manually, or by modifying cm_querysets.py or pgm_querysets.py files (on this branch).
When (if) merged, the branch should be changed to main by removing the line 'git checkout github_workflows', otherwise the update wants to consider the files on this branch not on main.